### PR TITLE
Support Scheduling for the Salesforce Input Plugin

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,7 +26,8 @@ into Logstash, one row per event. You can configure it to pull entire sObjects o
 specific fields.
 
 NOTE: This input plugin will stop after all the results of the query are processed and will
-need to be re-run to fetch new results. It does not utilize the streaming API.
+need to be re-run to fetch new results. It does not utilize the streaming API. You can
+periodically schedule ingestion using a cron syntax (see `schedule` setting)
 
 In order to use this plugin, you will need to create a new SFDC Application using
 oauth. More details can be found here:
@@ -38,6 +39,23 @@ https://help.salesforce.com/apex/HTViewHelpDoc?id=user_security_token.htm
 
 In addition to specifying an sObject, you can also supply a list of API fields
 that will be used in the SOQL query.
+
+==== Scheduling
+
+Input from this plugin can be scheduled to run periodically according to a specific
+schedule. This scheduling syntax is powered by https://github.com/jmettraux/rufus-scheduler[rufus-scheduler].
+The syntax is cron-like with some extensions specific to Rufus (e.g. timezone support ).
+
+Examples:
+
+|==========================================================
+| `* 5 * 1-3 *`               | will execute every minute of 5am every day of January through March.
+| `0 * * * *`                 | will execute on the 0th minute of every hour every day.
+| `0 6 * * * America/Chicago` | will execute at 6:00am (UTC/GMT -5) every day.
+|==========================================================
+
+
+Further documentation describing this syntax can be found https://github.com/jmettraux/rufus-scheduler#parsing-cronlines-and-time-strings[here].
 
 ==== Example
 This example prints all the Salesforce Opportunities to standard out
@@ -81,6 +99,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-to_underscores>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-use_test_sandbox>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-username>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -89,7 +108,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-api_version"]
-===== `api_version` 
+===== `api_version`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -98,7 +117,7 @@ By default, this uses the default Restforce API version.
 To override this, set this to something like "32.0" for example
 
 [id="plugins-{type}s-{plugin}-client_id"]
-===== `client_id` 
+===== `client_id`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -110,7 +129,7 @@ can be found here:
 https://help.salesforce.com/apex/HTViewHelpDoc?id=connected_app_create.htm
 
 [id="plugins-{type}s-{plugin}-client_secret"]
-===== `client_secret` 
+===== `client_secret`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -119,7 +138,7 @@ https://help.salesforce.com/apex/HTViewHelpDoc?id=connected_app_create.htm
 Consumer Secret from your oauth enabled connected app
 
 [id="plugins-{type}s-{plugin}-password"]
-===== `password` 
+===== `password`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -128,7 +147,7 @@ Consumer Secret from your oauth enabled connected app
 The password used to login to sfdc
 
 [id="plugins-{type}s-{plugin}-security_token"]
-===== `security_token` 
+===== `security_token`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -139,7 +158,7 @@ generting a security token, see:
 https://help.salesforce.com/apex/HTViewHelpDoc?id=user_security_token.htm
 
 [id="plugins-{type}s-{plugin}-sfdc_fields"]
-===== `sfdc_fields` 
+===== `sfdc_fields`
 
   * Value type is <<array,array>>
   * Default value is `[]`
@@ -148,7 +167,7 @@ These are the field names to return in the Salesforce query
 If this is empty, all fields are returned.
 
 [id="plugins-{type}s-{plugin}-sfdc_filters"]
-===== `sfdc_filters` 
+===== `sfdc_filters`
 
   * Value type is <<string,string>>
   * Default value is `""`
@@ -158,7 +177,7 @@ SOQL statement. Additional fields can be filtered on by
 adding field1 = value1 AND field2 = value2 AND...
 
 [id="plugins-{type}s-{plugin}-sfdc_object_name"]
-===== `sfdc_object_name` 
+===== `sfdc_object_name`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -167,7 +186,7 @@ adding field1 = value1 AND field2 = value2 AND...
 The name of the salesforce object you are creating or updating
 
 [id="plugins-{type}s-{plugin}-to_underscores"]
-===== `to_underscores` 
+===== `to_underscores`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -175,7 +194,7 @@ The name of the salesforce object you are creating or updating
 Setting this to true will convert SFDC's NamedFields__c to named_fields__c
 
 [id="plugins-{type}s-{plugin}-use_test_sandbox"]
-===== `use_test_sandbox` 
+===== `use_test_sandbox`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -184,7 +203,7 @@ Set this to true to connect to a sandbox sfdc instance
 logging in through test.salesforce.com
 
 [id="plugins-{type}s-{plugin}-username"]
-===== `username` 
+===== `username`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -194,7 +213,17 @@ A valid salesforce user name, usually your email address.
 Used for authentication and will be the user all objects
 are created or modified by
 
+[id="plugins-{type}s-{plugin}-schedule"]
+===== `schedule`
 
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Schedule of when to periodically run statement, in Cron format
+for example: "* * * * *" (execute query every minute, on the minute)
+
+There is no schedule by default. If no schedule is given, then the statement is run
+exactly once.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/inputs/salesforce.rb
+++ b/lib/logstash/inputs/salesforce.rb
@@ -83,10 +83,17 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
   config :sfdc_filters, :validate => :string, :default => ""
   # Setting this to true will convert SFDC's NamedFields__c to named_fields__c
   config :to_underscores, :validate => :boolean, :default => false
+  # Schedule of when to periodically run statement, in Cron format
+  # for example: "* * * * *" (execute query every minute, on the minute)
+  #
+  # There is no schedule by default. If no schedule is given, then the statement is run
+  # exactly once.
+  config :schedule, :validate => :string
 
   public
   def register
     require 'restforce'
+    require 'rufus/scheduler'
     obj_desc = client.describe(@sfdc_object_name)
     @sfdc_field_types = get_field_types(obj_desc)
     @sfdc_fields = get_all_fields if @sfdc_fields.empty?
@@ -94,6 +101,24 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
 
   public
   def run(queue)
+    if @schedule
+      @scheduler = Rufus::Scheduler.new(:max_worker_thread => 1)
+      @scheduler.cron @schedule do
+        execute_query(queue)
+      end
+
+      @scheduler.join
+    else
+      execute_query(queue)
+    end
+  end # def run
+
+  def stop
+    @scheduler.shutdown(:wait) if @scheduler
+  end
+
+  private
+  def execute_query(queue)
     results = client.query(get_query())
     if results && results.first
       results.each do |result|
@@ -115,7 +140,7 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
         queue << event
       end
     end
-  end # def run
+  end
 
   private
   def client

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -21,9 +21,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'restforce', '~> 3'
+  s.add_runtime_dependency 'rufus-scheduler'
+
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'json'
   s.add_development_dependency 'public_suffix', '~> 1.4.6' # required due to ruby < 2.0
+  s.add_development_dependency 'timecop'
 end


### PR DESCRIPTION
Adds support for scheduling the Salesforce Input Plugin within the pipeline. This currently doesn't hold any sort of state within the plugin or filesystem, this just allows for the re-running of the plugin from the plugin itself

Closes #19 