### PR TITLE
Make sure 'recent' restforce dependency is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+  - Make sure 'recent' restforce dependency is used (to help dependency resolution)
+
 ## 3.0.5
   - Docs: Set the default_codec doc attribute.
 
@@ -21,6 +24,6 @@
   - New dependency requirements for logstash-core for the 5.0 release
 
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-salesforce'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events based on a Salesforce SOQL query"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'restforce', '~> 3'
+  s.add_runtime_dependency 'restforce', '>= 3.2', '< 5'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'

--- a/spec/fixtures/vcr_cassettes/load_some_lead_objects.yml
+++ b/spec/fixtures/vcr_cassettes/load_some_lead_objects.yml
@@ -86,7 +86,7 @@ http_interactions:
   recorded_at: Thu, 27 Aug 2015 23:57:44 GMT
 - request:
     method: get
-    uri: https://eu2.salesforce.com/services/data/v26.0/query?q=SELECT%20Id,IsDeleted,LastName,FirstName,Salutation%20FROM%20Lead%20WHERE%20Email%20LIKE%20'%25@elastic.co'
+    uri: https://eu2.salesforce.com/services/data/v26.0/query?q=SELECT%20Id,IsDeleted,LastName,FirstName,Salutation%20FROM%20Lead%20WHERE%20Email%20LIKE%20%27%25@elastic.co%27
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
to help dependency resolution,
with `~> 3` Bundler was picking 3.2.0 (while latest is 4.2.2)

there was also a broken spec (failing with restforce 3.2.0 as well) due `'` encoding in http url