### PR TITLE
Added description for SALESFORCE_PROXY_URI environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.7
+  - Added description for `SALESFORCE_PROXY_URI` environment variable.
+
 ## 3.0.6
   - Make sure 'recent' restforce dependency is used (to help dependency resolution)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -39,6 +39,11 @@ https://help.salesforce.com/apex/HTViewHelpDoc?id=user_security_token.htm
 In addition to specifying an sObject, you can also supply a list of API fields
 that will be used in the SOQL query.
 
+==== Salesforce sandbox and HTTP proxy
+
+* By default, the plugin connects to `login.salesforce.com`. To use a Salesforce sandbox, set the `SALESFORCE_HOST` environment variable with the desired host value (e.g `export SALESFORCE_HOST="test.salesforce.com"`).
+* If your infrastructure uses a HTTP proxy, you can set the `SALESFORCE_PROXY_URI` environment variable with the desired URI value (e.g `export SALESFORCE_PROXY_URI="http://proxy.example.com:123"`).
+
 ==== Example
 This example prints all the Salesforce Opportunities to standard out
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -39,10 +39,9 @@ https://help.salesforce.com/apex/HTViewHelpDoc?id=user_security_token.htm
 In addition to specifying an sObject, you can also supply a list of API fields
 that will be used in the SOQL query.
 
-==== Salesforce sandbox and HTTP proxy
+==== HTTP proxy
 
-* By default, the plugin connects to `login.salesforce.com`. To use a Salesforce sandbox, set the `SALESFORCE_HOST` environment variable with the desired host value (e.g `export SALESFORCE_HOST="test.salesforce.com"`).
-* If your infrastructure uses a HTTP proxy, you can set the `SALESFORCE_PROXY_URI` environment variable with the desired URI value (e.g `export SALESFORCE_PROXY_URI="http://proxy.example.com:123"`).
+If your infrastructure uses a HTTP proxy, you can set the `SALESFORCE_PROXY_URI` environment variable with the desired URI value (e.g `export SALESFORCE_PROXY_URI="http://proxy.example.com:123"`).
 
 ==== Example
 This example prints all the Salesforce Opportunities to standard out

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-salesforce'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events based on a Salesforce SOQL query"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The `logstash-input-salesforce` plugins is built-on top of [Restforce](https://github.com/restforce/restforce#restforce). 

`SALESFORCE_PROXY_URI` environment variable can be used to route the traffic to a HTTP proxy.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
