### PR TITLE
feat: add config to use Salesforce Tooling API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Added `use_tooling_api` configuration to connect to the Salesforce Tooling API instead of the regular Rest API.
+
 ## 3.0.7
   - Added description for `SALESFORCE_PROXY_URI` environment variable.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 3.1.0
+## 3.2.0
   - Added `use_tooling_api` configuration to connect to the Salesforce Tooling API instead of the regular Rest API.
+
+## 3.1.0
   - Added `sfdc_instance_url` configuration to connect to a specific url.
   - Switch to restforce v5+ (for logstash 8.x compatibility)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.7
+  - Added description for `SALESFORCE_PROXY_URI` environment variable.
+
 ## 3.0.6
   - Make sure 'recent' restforce dependency is used (to help dependency resolution)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 3.2.0
-  - Added `use_tooling_api` configuration to connect to the Salesforce Tooling API instead of the regular Rest API.
+  - Added `use_tooling_api` configuration to connect to the Salesforce Tooling API instead of the regular Rest API. [#26](https://github.com/logstash-plugins/logstash-input-salesforce/pull/26)
 
 ## 3.1.0
-  - Added `sfdc_instance_url` configuration to connect to a specific url.
+  - Added `sfdc_instance_url` configuration to connect to a specific url. [#28](https://github.com/logstash-plugins/logstash-input-salesforce/pull/28)
   - Switch to restforce v5+ (for logstash 8.x compatibility)
 
 ## 3.0.7

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -84,6 +84,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-sfdc_object_name>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-to_underscores>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-use_test_sandbox>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-use_tooling_api>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-username>> |<<string,string>>|Yes
 |=======================================================================
 
@@ -186,6 +187,19 @@ Setting this to true will convert SFDC's NamedFields__c to named_fields__c
 
 Set this to true to connect to a sandbox sfdc instance
 logging in through test.salesforce.com
+
+[id="plugins-{type}s-{plugin}-use_tooling_api"]
+===== `use_tooling_api`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Set this to true to connect to the sfdc tooling api instead of the regular
+sfdc rest api. See
+https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling
+for details about the sfdc tooling api. Use cases for the sfdc tooling api
+include reading apex unit test results, flow coverage results (e.g. coverage
+of elements of sfdc flows) and security health check risks.
 
 [id="plugins-{type}s-{plugin}-username"]
 ===== `username` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -39,6 +39,10 @@ https://help.salesforce.com/apex/HTViewHelpDoc?id=user_security_token.htm
 In addition to specifying an sObject, you can also supply a list of API fields
 that will be used in the SOQL query.
 
+==== HTTP proxy
+
+If your infrastructure uses a HTTP proxy, you can set the `SALESFORCE_PROXY_URI` environment variable with the desired URI value (e.g `export SALESFORCE_PROXY_URI="http://proxy.example.com:123"`).
+
 ==== Example
 This example prints all the Salesforce Opportunities to standard out
 

--- a/lib/logstash/inputs/salesforce.rb
+++ b/lib/logstash/inputs/salesforce.rb
@@ -49,7 +49,11 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
   config_name "salesforce"
   default :codec, "plain" #not used
 
-  # Set this to true to connect via the Tooling API
+  # Set this to true to connect via the Tooling API instead of the Rest API.
+  # This allows accessing information like Apex Unit Test Results,
+  # Flow Coverage Results, Security Health Check Risks, etc.
+  # See https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling
+  # for more details about the Tooling API
   config :use_tooling_api, :validate => :boolean, :default => false
   # Set this to true to connect to a sandbox sfdc instance
   # logging in through test.salesforce.com

--- a/lib/logstash/inputs/salesforce.rb
+++ b/lib/logstash/inputs/salesforce.rb
@@ -49,6 +49,8 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
   config_name "salesforce"
   default :codec, "plain" #not used
 
+  # Set this to true to connect via the Tooling API
+  config :use_tooling_api, :validate => :boolean, :default => false
   # Set this to true to connect to a sandbox sfdc instance
   # logging in through test.salesforce.com
   config :use_test_sandbox, :validate => :boolean, :default => false
@@ -119,7 +121,11 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
 
   private
   def client
-    @client ||= Restforce.new client_options
+    if @use_tooling_api
+      @client ||= Restforce.tooling client_options
+    else
+      @client ||= Restforce.new client_options
+    end
   end
 
   private

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency "logstash-codec-plain", "~> 3.1"
   s.add_runtime_dependency 'restforce', '>= 3.2', '< 5'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'json'
-  s.add_development_dependency 'public_suffix', '~> 1.4.6' # required due to ruby < 2.0
+  s.add_development_dependency 'public_suffix', '~> 2.0' # required due to ruby < 2.0
 end

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-codec-plain"
+  s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency "restforce", ">= 5", "< 5.2"
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-codec-plain", ">= 3.0", "< 4"
-  s.add_runtime_dependency 'restforce', '>= 3.2', '< 5'
+  s.add_runtime_dependency "restforce", ">= 5", "< 5.2"
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'json'
-  s.add_development_dependency 'public_suffix', '~> 2.0' # required due to ruby < 2.0
+  s.add_development_dependency 'public_suffix', '>= 1.4' # required due to ruby < 2.0
 end

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-salesforce'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events based on a Salesforce SOQL query"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-salesforce'
-  s.version         = '3.0.7'
+  s.version         = '3.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events based on a Salesforce SOQL query"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-codec-plain", ">= 3.0", "< 4"
+  s.add_runtime_dependency "logstash-codec-plain"
   s.add_runtime_dependency "restforce", ">= 5", "< 5.2"
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-salesforce'
-  s.version         = '3.1.0'
+  s.version         = '3.2.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events based on a Salesforce SOQL query"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-codec-plain", "~> 3.1"
+  s.add_runtime_dependency "logstash-codec-plain", ">= 3.0", "< 4"
   s.add_runtime_dependency 'restforce', '>= 3.2', '< 5'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'

--- a/spec/fixtures/vcr_cassettes/describe_apex_test_run_result_object.yml
+++ b/spec/fixtures/vcr_cassettes/describe_apex_test_run_result_object.yml
@@ -1,0 +1,162 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.salesforce.com/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=xxxx&client_secret=xxxx&username=xxxx&password=xxxx
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Aug 2015 21:31:28 GMT
+      Set-Cookie:
+      - BrowserId=xxxx;Path=/;Domain=.salesforce.com;Expires=Mon, 26-Oct-2015 21:31:28 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: US-ASCII
+      string: '{"id":"https://login.salesforce.com/id/xxxx/xxxx","issued_at":"1440711088469","token_type":"Bearer","instance_url":"https://eu2.salesforce.com","signature":"xxxx","access_token":"xxxx"}'
+    http_version:
+  recorded_at: Thu, 27 Aug 2015 21:31:28 GMT
+- request:
+    method: get
+    uri: https://eu2.salesforce.com/services/data/v52.0/tooling/sobjects/ApexTestRunResult/describe
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth xxxx
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Aug 2015 21:31:29 GMT
+      Set-Cookie:
+      - BrowserId=xxxx;Path=/;Domain=.salesforce.com;Expires=Mon, 26-Oct-2015 21:31:29 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=204568/451000
+      Org.eclipse.jetty.server.include.etag:
+      - f3049665
+      Last-Modified:
+      - Thu, 27 Aug 2015 18:14:47 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Etag:
+      - f304966-gzip"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"actionOverrides":[],"activateable":false,"associateEntityType":null,"associateParentEntity":null,"childRelationships":[],"compactLayoutable":false,"createable":true,"custom":false,"customSetting":false,"deepCloneable":false,"defaultImplementation":null,
+        "deletable":true,"deprecatedAndHidden":false,"extendedBy":null,"extendsInterfaces":null,"feedEnabled":false,"fields":[{"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,
+        "caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,
+        "displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":true,
+        "inlineHelpText":null,"label":"ApexTestRunResult ID","length":18,"mask":null,"maskType":null,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,"precision":0,
+        "queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"tns:ID","sortable":true,"type":"id",
+        "unique":false,"updateable":false,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":true,"compoundFieldName":null,
+        "controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,
+        "extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Apex Job ID","length":18,"mask":null,
+        "maskType":null,"name":"AsyncApexJobId","nameField":false,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":["AsyncApexJob"],
+        "relationshipName":"AsyncApexJob","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"tns:ID","sortable":true,"type":"reference","unique":true,"updateable":true,
+        "writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,
+        "createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,
+        "filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"User ID","length":18,"mask":null,"maskType":null,"name":"UserId",
+        "nameField":false,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":["User"],"relationshipName":"User","relationshipOrder":null,
+        "restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,
+        "autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,
+        "defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,
+        "groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Name of the job","length":255,"mask":null,"maskType":null,"name":"JobName","nameField":false,"namePointing":false,"nillable":true,"permissionable":false,
+        "picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,
+        "searchPrefilterable":false,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"aggregatable":false,"aiPredictionField":false,"autoNumber":false,"byteLength":0,"calculated":false,
+        "calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":false,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,
+        "deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,
+        "htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"allTests","length":0,"mask":null,"maskType":null,"name":"IsAllTests","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],
+        "polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,
+        "soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,
+        "cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,
+        "displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,
+        "inlineHelpText":null,"label":"Client that kicked off the test run","length":255,"mask":null,"maskType":null,"name":"Source","nameField":false,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,
+        "precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"xsd:string","sortable":true,
+        "type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,
+        "compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,
+        "encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":false,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,
+        "label":"Start time of the test run","length":0,"mask":null,"maskType":null,"name":"StartTime","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,
+        "referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,
+        "updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,
+        "createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,
+        "filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":false,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"End time of the test run","length":0,"mask":null,"maskType":null,
+        "name":"EndTime","nameField":false,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,
+        "relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,
+        "aiPredictionField":false,"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,
+        "defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":9,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,
+        "formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Time(ms) actually spent running tests","length":0,"mask":null,"maskType":null,"name":"TestTime","nameField":false,
+        "namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,
+        "restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"xsd:int","sortable":true,"type":"int","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,
+        "autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,
+        "defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,
+        "groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Status of the test run","length":255,"mask":null,"maskType":null,"name":"Status","nameField":false,"namePointing":false,"nillable":false,
+        "permissionable":false,"picklistValues":[{"active":true,"defaultValue":false,"label":"Queued","validFor":null,"value":"Queued"},{"active":true,"defaultValue":false,"label":"Processing","validFor":null,"value":"Processing"},{"active":true,"defaultValue":false,
+        "label":"Aborted","validFor":null,"value":"Aborted"},{"active":true,"defaultValue":false,"label":"Completed","validFor":null,"value":"Completed"},{"active":true,"defaultValue":false,"label":"Failed","validFor":null,"value":"Failed"},{"active":true,
+        "defaultValue":false,"label":"Preparing","validFor":null,"value":"Preparing"},{"active":true,"defaultValue":false,"label":"Holding","validFor":null,"value":"Holding"}],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,
+        "referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":true,"scale":0,"searchPrefilterable":false,"soapType":"xsd:string","sortable":true,"type":"picklist","unique":false,
+        "updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,
+        "controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":9,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,
+        "extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Number of classes enqueued in this test run",
+        "length":0,"mask":null,"maskType":null,"name":"ClassesEnqueued","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,
+        "referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"xsd:int","sortable":true,"type":"int","unique":false,"updateable":true,"writeRequiresMasterRead":false},
+        {"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,
+        "defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":9,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,
+        "formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Number of classes completed in this test run","length":0,"mask":null,"maskType":null,"name":"ClassesCompleted",
+        "nameField":false,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,
+        "restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"xsd:int","sortable":true,"type":"int","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,
+        "autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,
+        "defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":9,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,
+        "groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Number of methods enqueued in this test run","length":0,"mask":null,"maskType":null,"name":"MethodsEnqueued","nameField":false,"namePointing":false,
+        "nillable":true,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,
+        "restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"xsd:int","sortable":true,"type":"int","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":0,
+        "calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,
+        "deprecatedAndHidden":false,"digits":9,"displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,
+        "htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Number of methods completed in this test run","length":0,"mask":null,"maskType":null,"name":"MethodsCompleted","nameField":false,"namePointing":false,"nillable":true,"permissionable":false,
+        "picklistValues":[],"polymorphicForeignKey":false,"precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,
+        "searchPrefilterable":false,"soapType":"xsd:int","sortable":true,"type":"int","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"aggregatable":true,"aiPredictionField":false,"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,
+        "cascadeDelete":false,"caseSensitive":false,"compoundFieldName":null,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":9,
+        "displayLocationInDecimal":false,"encrypted":false,"externalId":false,"extraTypeInfo":null,"filterable":true,"filteredLookupInfo":null,"formulaTreatNullNumberAsZero":false,"groupable":true,"highScaleNumber":false,"htmlFormatted":false,"idLookup":false,
+        "inlineHelpText":null,"label":"Number of methods failed in this test run","length":0,"mask":null,"maskType":null,"name":"MethodsFailed","nameField":false,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"polymorphicForeignKey":false,
+        "precision":0,"queryByDistance":false,"referenceTargetField":null,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"searchPrefilterable":false,"soapType":"xsd:int","sortable":true,
+        "type":"int","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"hasSubtypes":false,"implementedBy":null,"implementsInterfaces":null,"isInterface":false,"isSubtype":false,"keyPrefix":"05m","label":"Apex Test Run Result",
+        "labelPlural":"Apex Test Run Result","layoutable":false,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"mruEnabled":false,"name":"ApexTestRunResult","namedLayoutInfos":[],"networkScopeFieldName":null,"queryable":true,"recordTypeInfos":[],
+        "replicateable":false,"retrieveable":true,"searchLayoutable":false,"searchable":false,"sobjectDescribeOption":"FULL","supportedScopes":[{"label":"All apex test run results","name":"everything"}],"triggerable":false,"undeletable":false,"updateable":true,
+        "urls":{"rowTemplate":"/services/data/v52.0/tooling/sobjects/ApexTestRunResult/{ID}","describe":"/services/data/v52.0/tooling/sobjects/ApexTestRunResult/describe","sobject":"/services/data/v52.0/tooling/sobjects/ApexTestRunResult"}}'
+    http_version:
+  recorded_at: Thu, 27 Aug 2015 21:31:30 GMT
+recorded_with: VCR 2.9.3

--- a/spec/inputs/salesforce_spec.rb
+++ b/spec/inputs/salesforce_spec.rb
@@ -119,5 +119,41 @@ RSpec.describe LogStash::Inputs::Salesforce do
         end
       end
     end
+
+    context "use Tooling Api" do
+      VCR.configure do |config|
+        config.cassette_library_dir = File.join(File.dirname(__FILE__), '..', 'fixtures', 'vcr_cassettes')
+        config.hook_into :webmock
+        config.before_record do |i|
+          if i.response.body.encoding.to_s == 'ASCII-8BIT'
+            # required because sfdc doesn't send back the content encoding and it
+            # confuses the yaml parser
+            json_body = JSON.load(i.response.body.encode("ASCII-8BIT").force_encoding("utf-8"))
+            i.response.body = json_body.to_json
+            i.response.update_content_length_header
+          end
+        end
+      end
+      let(:options) do
+        {
+          "api_version" => "52.0",
+          "client_id" => "",
+          "client_secret" => "",
+          "username" => "",
+          "password" => "",
+          "security_token" => "",
+          "use_tooling_api" => true,
+          "sfdc_object_name" => "ApexTestRunResult"
+        }
+      end
+      let(:input) { LogStash::Inputs::Salesforce.new(options) }
+      subject { input }
+      it "should use the Tooling Api Query resource path" do
+        VCR.use_cassette("describe_apex_test_run_result_object",:decode_compressed_response => true) do
+          subject.register
+          expect(subject.send(:client).send(:api_path, "query")).to eq('/services/data/v52.0/tooling/query')
+        end
+      end
+    end
   end
 end

--- a/spec/inputs/salesforce_spec.rb
+++ b/spec/inputs/salesforce_spec.rb
@@ -214,9 +214,8 @@ RSpec.describe LogStash::Inputs::Salesforce do
         VCR.use_cassette("describe_apex_test_run_result_object",:decode_compressed_response => true) do
           subject.register
           expect(subject.send(:client).send(:api_path, "query")).to eq('/services/data/v52.0/tooling/query')
-        }
+        end
       end
-
     end
   end
 end


### PR DESCRIPTION
Salesforce provides information relevant for monitoring of a Salesforce application not only via the standard REST APIs but also via the Tooling API. I.e. the SecurityHealthCheck Score which is a measure also shown within Salesforce telling an admin how their org compares to the security baseline recommended by Salesforce. Extracting this SecurityHealthCheck Score and importing it as a metric to Elasticsearch provides the capability to follow the evolution of the score over time and identify trends.
Example of a pipeline leveraging the Tooling API:
```
input {
    salesforce {
        api_version => '51.0'
        ...
        use_tooling_api => true
        sfdc_object_name => 'SecurityHealthCheck'
        sfdc_fields => [ 'Score' ]
    }
}

output {
    stdout {
        codec => rubydebug
    }
}
```

Output:
```
{
         "Score" => "74"
      "@version" => "1",
    "@timestamp" => 2021-04-21T19:25:29.074Z
}
```

Closes logstash-plugins/logstash-input-salesforce#27