### PR TITLE
Add settings to connect to Salesforce MyDomain url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.0
   - Added `sfdc_instance_url` configuration to connect to a specific url.
+  - Switch to restforce v5+ (for logstash 8.x compatibility)
 
 ## 3.0.7
   - Added description for `SALESFORCE_PROXY_URI` environment variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Added `sfdc_instance_url` configuration to connect to a specific url.
+
 ## 3.0.7
   - Added description for `SALESFORCE_PROXY_URI` environment variable.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -168,9 +168,9 @@ adding field1 = value1 AND field2 = value2 AND...
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-The url of a salesforce instance. Provide this if you already
-during login want to connect to your instance url instead of
-`login.salesforce.com` or `test.salesforce.com`.
+The url of a Salesforce instance. Provide the url if you want to connect
+to your Salesforce instance instead of
+`login.salesforce.com` or `test.salesforce.com` at login.
 
 Use either this or the `use_test_sandbox` configuration option
 but not both to configure the url to which the plugin connects to.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -172,6 +172,9 @@ The url of a salesforce instance. Provide this if you already
 during login want to connect to your instance url instead of
 `login.salesforce.com` or `test.salesforce.com`.
 
+Use either this or the `use_test_sandbox` configuration option
+but not both to configure the url to which the plugin connects to.
+
 [id="plugins-{type}s-{plugin}-sfdc_object_name"]
 ===== `sfdc_object_name` 
 
@@ -197,6 +200,10 @@ Setting this to true will convert SFDC's NamedFields__c to named_fields__c
 
 Set this to true to connect to a sandbox sfdc instance
 logging in through test.salesforce.com
+
+Use either this or the `sfdc_instance_url` configuration option
+but not both to configure the url to which the plugin connects to.
+
 
 [id="plugins-{type}s-{plugin}-username"]
 ===== `username` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -81,6 +81,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-security_token>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-sfdc_fields>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-sfdc_filters>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sfdc_instance_url>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sfdc_object_name>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-to_underscores>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-use_test_sandbox>> |<<boolean,boolean>>|No
@@ -160,6 +161,16 @@ If this is empty, all fields are returned.
 These options will be added to the WHERE clause in the
 SOQL statement. Additional fields can be filtered on by
 adding field1 = value1 AND field2 = value2 AND...
+
+[id="plugins-{type}s-{plugin}-sfdc_instance_url"]
+===== `sfdc_instance_url`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The url of a salesforce instance. Provide this if you already
+during login want to connect to your instance url instead of
+`login.salesforce.com` or `test.salesforce.com`.
 
 [id="plugins-{type}s-{plugin}-sfdc_object_name"]
 ===== `sfdc_object_name` 

--- a/lib/logstash/inputs/salesforce.rb
+++ b/lib/logstash/inputs/salesforce.rb
@@ -52,8 +52,10 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
   # Set this to true to connect to a sandbox sfdc instance
   # logging in through test.salesforce.com
   config :use_test_sandbox, :validate => :boolean, :default => false
-  # Set this to the custom MyDomain url of your sfdc instance
-  # logging in through instance url
+  # Set this to the instance url of the sfdc instance you want
+  # to connect to already during login. If you have configured
+  # a MyDomain in your sfdc instance you would provide
+  # <mydomain>.my.salesforce.com here.
   config :sfdc_instance_url, :validate => :string, :required => false
   # By default, this uses the default Restforce API version.
   # To override this, set this to something like "32.0" for example

--- a/lib/logstash/inputs/salesforce.rb
+++ b/lib/logstash/inputs/salesforce.rb
@@ -136,8 +136,14 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
       :client_id      => @client_id,
       :client_secret  => @client_secret
     }
-    options.merge!({ :host => @sfdc_instance_url }) if @sfdc_instance_url
-    options.merge!({ :host => "test.salesforce.com" }) if @use_test_sandbox and not @sfdc_instance_url
+    # configure the endpoint to which restforce connects to for authentication
+    if @sfdc_instance_url && @use_test_sandbox
+      raise ::LogStash::ConfigurationError.new("Both \"use_test_sandbox\" and \"sfdc_instance_url\" can't be set simultaneously. Please specify either \"use_test_sandbox\" or \"sfdc_instance_url\"")
+    elsif @sfdc_instance_url
+      options.merge!({ :host => @sfdc_instance_url })
+    elsif @use_test_sandbox
+      options.merge!({ :host => "test.salesforce.com" })
+    end
     options.merge!({ :api_version => @api_version }) if @api_version
     return options
   end

--- a/lib/logstash/inputs/salesforce.rb
+++ b/lib/logstash/inputs/salesforce.rb
@@ -52,6 +52,9 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
   # Set this to true to connect to a sandbox sfdc instance
   # logging in through test.salesforce.com
   config :use_test_sandbox, :validate => :boolean, :default => false
+  # Set this to the custom MyDomain url of your sfdc instance
+  # logging in through instance url
+  config :sfdc_instance_url, :validate => :string, :required => false
   # By default, this uses the default Restforce API version.
   # To override this, set this to something like "32.0" for example
   config :api_version, :validate => :string, :required => false
@@ -131,7 +134,8 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
       :client_id      => @client_id,
       :client_secret  => @client_secret
     }
-    options.merge!({ :host => "test.salesforce.com" }) if @use_test_sandbox
+    options.merge!({ :host => @sfdc_instance_url }) if @sfdc_instance_url
+    options.merge!({ :host => "test.salesforce.com" }) if @use_test_sandbox and not @sfdc_instance_url
     options.merge!({ :api_version => @api_version }) if @api_version
     return options
   end

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency "logstash-codec-plain", "~> 3.1"
   s.add_runtime_dependency 'restforce', '>= 3.2', '< 5'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'json'
-  s.add_development_dependency 'public_suffix', '~> 1.4.6' # required due to ruby < 2.0
+  s.add_development_dependency 'public_suffix', '~> 2.0' # required due to ruby < 2.0
 end

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-codec-plain", ">= 3.0", "< 4"
-  s.add_runtime_dependency 'restforce', '>= 3.2', '< 5'
+  s.add_runtime_dependency "restforce", ">= 5", "< 5.2"
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'json'
-  s.add_development_dependency 'public_suffix', '~> 2.0' # required due to ruby < 2.0
+  s.add_development_dependency 'public_suffix', '>= 1.4' # required due to ruby < 2.0
 end

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-salesforce'
-  s.version         = '3.0.7'
+  s.version         = '3.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events based on a Salesforce SOQL query"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-codec-plain", ">= 3.0", "< 4"
+  s.add_runtime_dependency "logstash-codec-plain"
   s.add_runtime_dependency "restforce", ">= 5", "< 5.2"
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-codec-plain", "~> 3.1"
+  s.add_runtime_dependency "logstash-codec-plain", ">= 3.0", "< 4"
   s.add_runtime_dependency 'restforce', '>= 3.2', '< 5'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'vcr'

--- a/spec/fixtures/vcr_cassettes/login_into_mydomain.yml
+++ b/spec/fixtures/vcr_cassettes/login_into_mydomain.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://my-domain.my.salesforce.com/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=xxxx&client_secret=xxxx&username=xxxx&password=xxxx
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Aug 2015 21:31:28 GMT
+      Set-Cookie:
+      - BrowserId=xxxx;Path=/;Domain=.salesforce.com;Expires=Mon, 26-Oct-2015 21:31:28 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: US-ASCII
+      string: '{"id":"https://login.salesforce.com/id/xxxx/xxxx","issued_at":"1440711088469","token_type":"Bearer","instance_url":"https://my-domain.my.salesforce.com","signature":"xxxx","access_token":"xxxx"}'
+    http_version:
+  recorded_at: Thu, 27 Aug 2015 21:31:28 GMT
+- request:
+    method: get
+    uri: https://my-domain.my.salesforce.com/services/data/v26.0/sobjects/Lead/describe
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth xxxx
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Aug 2015 21:31:29 GMT
+      Set-Cookie:
+      - BrowserId=xxxx;Path=/;Domain=.salesforce.com;Expires=Mon, 26-Oct-2015 21:31:29 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=204568/451000
+      Org.eclipse.jetty.server.include.etag:
+      - f3049665
+      Last-Modified:
+      - Thu, 27 Aug 2015 18:14:47 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Etag:
+      - f304966-gzip"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"activateable":false,"childRelationships":[],"createable":true,"custom":false,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":true,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Lead
+        ID","length":18,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"id","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Deleted","length":0,"name":"IsDeleted","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":240,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
+        Name","length":80,"name":"LastName","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":120,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"First
+        Name","length":40,"name":"FirstName","nameField":false,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":120,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Salutation","length":40,"name":"Salutation","nameField":false,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[{"active":true,"defaultValue":false,"label":"Mr.","validFor":null,"value":"Mr."},{"active":true,"defaultValue":false,"label":"Ms.","validFor":null,"value":"Ms."},{"active":true,"defaultValue":false,"label":"Mrs.","validFor":null,"value":"Mrs."},{"active":true,"defaultValue":false,"label":"Dr.","validFor":null,"value":"Dr."},{"active":true,"defaultValue":false,"label":"Prof.","validFor":null,"value":"Prof."}],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"picklist","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"00Q","label":"Lead","labelPlural":"Leads","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":true,"name":"Lead","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Marketing","recordTypeId":"xxxx"},{"available":true,"defaultRecordTypeMapping":false,"name":"Partner
+        Deal","recordTypeId":"xxxx"},{"available":true,"defaultRecordTypeMapping":false,"name":"Sales","recordTypeId":"xxxx"},{"available":true,"defaultRecordTypeMapping":false,"name":"Master","recordTypeId":"xxxx"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://xxx.salesforce.com/{ID}/e","sobject":"/services/data/v26.0/sobjects/Lead","uiDetailTemplate":"https://xxx.salesforce.com/{ID}","describe":"/services/data/v26.0/sobjects/Lead/describe","rowTemplate":"/services/data/v26.0/sobjects/Lead/{ID}","uiNewRecord":"https://xxx.salesforce.com/00Q/e"}}'
+    http_version:
+  recorded_at: Thu, 27 Aug 2015 21:31:30 GMT
+recorded_with: VCR 2.9.3

--- a/spec/inputs/salesforce_spec.rb
+++ b/spec/inputs/salesforce_spec.rb
@@ -119,5 +119,48 @@ RSpec.describe LogStash::Inputs::Salesforce do
         end
       end
     end
+
+    context "use sfdc instance url" do
+      VCR.configure do |config|
+        config.cassette_library_dir = File.join(File.dirname(__FILE__), '..', 'fixtures', 'vcr_cassettes')
+        config.hook_into :webmock
+        config.before_record do |i|
+          if i.response.body.encoding.to_s == 'ASCII-8BIT'
+            # required because sfdc doesn't send back the content encoding and it
+            # confuses the yaml parser
+            json_body = JSON.load(i.response.body.encode("ASCII-8BIT").force_encoding("utf-8"))
+            i.response.body = json_body.to_json
+            i.response.update_content_length_header
+          end
+        end
+      end
+      let(:options) do
+        {
+          "client_id" => "",
+          "client_secret" => "",
+          "username" => "",
+          "password" => "",
+          "security_token" => "",
+          "sfdc_instance_url" => "my-domain.my.salesforce.com",
+          "sfdc_object_name" => "Lead"
+        }
+      end
+      let (:input) { LogStash::Inputs::Salesforce.new(options) }
+      let(:expected_fields_result) { ["Id", "IsDeleted",
+                                      "LastName", "FirstName", "Salutation"] }
+      let(:expected_types_result) { [["FirstName", "string"],
+                                     ["Id", "id"],
+                                     ["IsDeleted", "boolean"],
+                                     ["LastName", "string"],
+                                     ["Salutation", "picklist"]] }
+      subject { input }
+      it "logs into sfdc instance url" do
+        VCR.use_cassette("login_into_mydomain", :decode_compressed_response => true) do
+          subject.register
+          expect(subject.instance_variable_get(:@sfdc_field_types)).to match_array(expected_types_result)
+          expect(subject.instance_variable_get(:@sfdc_fields)).to match_array(expected_fields_result)
+        end
+      end
+    end
   end
 end

--- a/spec/inputs/salesforce_spec.rb
+++ b/spec/inputs/salesforce_spec.rb
@@ -161,6 +161,25 @@ RSpec.describe LogStash::Inputs::Salesforce do
           expect(subject.instance_variable_get(:@sfdc_fields)).to match_array(expected_fields_result)
         end
       end
+      context "...but not use_test_sandbox" do
+        let(:options) do
+          {
+            "client_id" => "",
+            "client_secret" => "",
+            "username" => "",
+            "password" => "",
+            "security_token" => "",
+            "sfdc_instance_url" => "my-domain.my.salesforce.com",
+            "sfdc_object_name" => "Lead",
+            "use_test_sandbox" => true
+          }
+        end
+        let (:input) { LogStash::Inputs::Salesforce.new(options) }
+        subject { input }
+        it "should raise a LogStash::ConfigurationError" do
+          expect { subject.register }.to raise_error(::LogStash::ConfigurationError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Which use case is this pull request trying to solve

We are operating in an environment where we need to explicitly put Salesforce IPs into an allow-list to be able to connect. We are pushed to limit the number of IPs that we are requesting. For us it would hence be helpful to narrow down the number of IPs that we need to connect to. For this we would like more control over which Salesforce endpoint is used by the Salesforce input plugin for authentication and for further API requests. The latter would usually go to the instance url which is returned by the login request. The login request would always go to either login.salesforce.com or test.salesforce.com (depending on the value of the `use_test_sandbox` setting).

# What does this pull request do

This pull request introduces a new configuration setting of the Salesforce input plugin which allows to provide the Salesforce instance url to connect to (already) for authentication and further API requests. The configuration parameter is named `sfdc_instance_url` and takes a string value of the form `<mydomain>.my.salesforce.com`, e.g. the hostname part of the instance url without protocol or path.
If a `sfdc_instance_url` is given, it takes precedence over the `use_test_sandbox` setting and controls the endpoint to which the login request is sent.
If `sfdc_instance_url` is not set, then the `use_test_sandbox` setting will control which endpoint is used.