### PR TITLE
Change sensitive configs type to `Password`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+  - Changes sensitive configs type to Password for better protection from leaks in debug logs. [#35](https://github.com/logstash-plugins/logstash-input-salesforce/pull/35)
+
 ## 3.2.0
   - Added `use_tooling_api` configuration to connect to the Salesforce Tooling API instead of the regular Rest API. [#26](https://github.com/logstash-plugins/logstash-input-salesforce/pull/26)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -76,9 +76,9 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-api_version>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-client_id>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-client_secret>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-password>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-security_token>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-client_secret>> |<<password,password>>|Yes
+| <<plugins-{type}s-{plugin}-password>> |<<password,password>>|Yes
+| <<plugins-{type}s-{plugin}-security_token>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-sfdc_fields>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-sfdc_filters>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sfdc_instance_url>> |<<string,string>>|No
@@ -119,7 +119,7 @@ https://help.salesforce.com/apex/HTViewHelpDoc?id=connected_app_create.htm
 ===== `client_secret` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 Consumer Secret from your oauth enabled connected app
@@ -128,7 +128,7 @@ Consumer Secret from your oauth enabled connected app
 ===== `password` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 The password used to login to sfdc
@@ -137,7 +137,7 @@ The password used to login to sfdc
 ===== `security_token` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 The security token for this account. For more information about

--- a/lib/logstash/inputs/salesforce.rb
+++ b/lib/logstash/inputs/salesforce.rb
@@ -72,17 +72,17 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
   # https://help.salesforce.com/apex/HTViewHelpDoc?id=connected_app_create.htm
   config :client_id, :validate => :string, :required => true
   # Consumer Secret from your oauth enabled connected app
-  config :client_secret, :validate => :string, :required => true
+  config :client_secret, :validate => :password, :required => true
   # A valid salesforce user name, usually your email address.
   # Used for authentication and will be the user all objects
   # are created or modified by
   config :username, :validate => :string, :required => true
   # The password used to login to sfdc
-  config :password, :validate => :string, :required => true
+  config :password, :validate => :password, :required => true
   # The security token for this account. For more information about
   # generting a security token, see:
   # https://help.salesforce.com/apex/HTViewHelpDoc?id=user_security_token.htm
-  config :security_token, :validate => :string, :required => true
+  config :security_token, :validate => :password, :required => true
   # The name of the salesforce object you are creating or updating
   config :sfdc_object_name, :validate => :string, :required => true
   # These are the field names to return in the Salesforce query
@@ -141,10 +141,10 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
   def client_options
     options = {
       :username       => @username,
-      :password       => @password,
-      :security_token => @security_token,
+      :password       => @password.value,
+      :security_token => @security_token.value,
       :client_id      => @client_id,
-      :client_secret  => @client_secret
+      :client_secret  => @client_secret.value
     }
     # configure the endpoint to which restforce connects to for authentication
     if @sfdc_instance_url && @use_test_sandbox

--- a/logstash-input-salesforce.gemspec
+++ b/logstash-input-salesforce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-salesforce'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events based on a Salesforce SOQL query"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/salesforce_spec.rb
+++ b/spec/inputs/salesforce_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe LogStash::Inputs::Salesforce do
     let(:options) do
       {
         "client_id" => "",
-        "client_secret" => "",
+        "client_secret" => ::LogStash::Util::Password.new("secret-key"),
         "username" => "",
-        "password" => "",
-        "security_token" => "",
+        "password" => ::LogStash::Util::Password.new("secret-password"),
+        "security_token" => ::LogStash::Util::Password.new("secret-token"),
         "sfdc_object_name" => ""
       }
     end
@@ -35,10 +35,10 @@ RSpec.describe LogStash::Inputs::Salesforce do
       let(:options) do
         {
           "client_id" => "",
-          "client_secret" => "",
+          "client_secret" => ::LogStash::Util::Password.new("secret-key"),
           "username" => "",
-          "password" => "",
-          "security_token" => "",
+          "password" => ::LogStash::Util::Password.new("secret-password"),
+          "security_token" => ::LogStash::Util::Password.new("secret-token"),
           "sfdc_object_name" => "Lead",
           "sfdc_fields" => ["Something"]
         }
@@ -67,10 +67,10 @@ RSpec.describe LogStash::Inputs::Salesforce do
       let(:options) do
         {
           "client_id" => "",
-          "client_secret" => "",
+          "client_secret" => ::LogStash::Util::Password.new("secret-key"),
           "username" => "",
-          "password" => "",
-          "security_token" => "",
+          "password" => ::LogStash::Util::Password.new("secret-password"),
+          "security_token" => ::LogStash::Util::Password.new("secret-token"),
           "sfdc_object_name" => "Lead"
         }
       end
@@ -94,10 +94,10 @@ RSpec.describe LogStash::Inputs::Salesforce do
         let(:options) do
           {
             "client_id" => "",
-            "client_secret" => "",
+            "client_secret" => ::LogStash::Util::Password.new("secret-key"),
             "username" => "",
-            "password" => "",
-            "security_token" => "",
+            "password" => ::LogStash::Util::Password.new("secret-password"),
+            "security_token" => ::LogStash::Util::Password.new("secret-token"),
             "sfdc_object_name" => "Lead",
             "sfdc_fields" => ["Id", "IsDeleted", "LastName", "FirstName", "Salutation"],
             "sfdc_filters" => "Email LIKE '%@elastic.co'"
@@ -137,10 +137,10 @@ RSpec.describe LogStash::Inputs::Salesforce do
       let(:options) do
         {
           "client_id" => "",
-          "client_secret" => "",
+          "client_secret" => ::LogStash::Util::Password.new("secret-key"),
           "username" => "",
-          "password" => "",
-          "security_token" => "",
+          "password" => ::LogStash::Util::Password.new("secret-password"),
+          "security_token" => ::LogStash::Util::Password.new("secret-token"),
           "sfdc_instance_url" => "my-domain.my.salesforce.com",
           "sfdc_object_name" => "Lead"
         }
@@ -165,10 +165,10 @@ RSpec.describe LogStash::Inputs::Salesforce do
         let(:options) do
           {
             "client_id" => "",
-            "client_secret" => "",
+            "client_secret" => ::LogStash::Util::Password.new("secret-key"),
             "username" => "",
-            "password" => "",
-            "security_token" => "",
+            "password" => ::LogStash::Util::Password.new("secret-password"),
+            "security_token" => ::LogStash::Util::Password.new("secret-token"),
             "sfdc_instance_url" => "my-domain.my.salesforce.com",
             "sfdc_object_name" => "Lead",
             "use_test_sandbox" => true
@@ -200,10 +200,10 @@ RSpec.describe LogStash::Inputs::Salesforce do
         {
           "api_version" => "52.0",
           "client_id" => "",
-          "client_secret" => "",
+          "client_secret" => ::LogStash::Util::Password.new("secret-key"),
           "username" => "",
-          "password" => "",
-          "security_token" => "",
+          "password" => ::LogStash::Util::Password.new("secret-password"),
+          "security_token" => ::LogStash::Util::Password.new("secret-token"),
           "use_tooling_api" => true,
           "sfdc_object_name" => "ApexTestRunResult"
         }


### PR DESCRIPTION
### Description
This PR ensures to protect the `password`, `security_token` and `client_secret` from leaks in the debug logs.

- Closes #34

### Test
```
# config
input {
      salesforce {
        client_id => "OAUTH_CLIENT_ID_FROM_YOUR_SFDC_APP"
        client_secret => "OAUTH_CLIENT_SECRET"
        username => "email@example.com"
        password => "super-secret"
        security_token => "SECURITY_TOKEN"
        sfdc_object_name => "Opportunity"
      }
}
output {
    stdout {}
}
```


```
# Log before change
# Log before change
[2022-12-01T18:05:17,380][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@password = "super-secret"
[2022-12-01T18:05:17,380][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@sfdc_object_name = "Opportunity"
[2022-12-01T18:05:17,380][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@security_token = "SECURITY_TOKEN"
[2022-12-01T18:05:17,380][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@client_secret = "OAUTH_CLIENT_SECRET"
[2022-12-01T18:05:17,380][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@id = "bd7dc92c85796c3ea5c00db2b609c7de40dbe32a5b98bf14df4a66139f117090"
[2022-12-01T18:05:17,380][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@client_id = "OAUTH_CLIENT_ID_FROM_YOUR_SFDC_APP"

# Log after change
[2022-12-01T18:01:36,390][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@password = <password>
[2022-12-01T18:01:36,390][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@sfdc_object_name = "Opportunity"
[2022-12-01T18:01:36,390][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@security_token = <password>
[2022-12-01T18:01:36,390][DEBUG][logstash.inputs.salesforce] config LogStash::Inputs::Salesforce/@client_secret = <password>
```