### PR TITLE
feat: timeout configuration

### DIFF
--- a/lib/logstash/inputs/salesforce.rb
+++ b/lib/logstash/inputs/salesforce.rb
@@ -92,6 +92,8 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
   # SOQL statement. Additional fields can be filtered on by
   # adding field1 = value1 AND field2 = value2 AND...
   config :sfdc_filters, :validate => :string, :default => ""
+  # RESTForce request timeout in seconds.
+  config :timeout, :validate => :number, :default => 60, :required => false
   # Setting this to true will convert SFDC's NamedFields__c to named_fields__c
   config :to_underscores, :validate => :boolean, :default => false
 
@@ -144,7 +146,8 @@ class LogStash::Inputs::Salesforce < LogStash::Inputs::Base
       :password       => @password.value,
       :security_token => @security_token.value,
       :client_id      => @client_id,
-      :client_secret  => @client_secret.value
+      :client_secret  => @client_secret.value,
+      :timeout        => @timeout
     }
     # configure the endpoint to which restforce connects to for authentication
     if @sfdc_instance_url && @use_test_sandbox


### PR DESCRIPTION
Adds a timeout configuration option to change the timeout of REST API calls to Salesforce from the default 60 seconds to something else.